### PR TITLE
Prevent scrollY reset when closing the lightbox

### DIFF
--- a/dist/lite-light.min.js
+++ b/dist/lite-light.min.js
@@ -144,8 +144,10 @@ function B(t = {}) {
     o.style.display = "flex", m(r[d].getAttribute(l.imageUrlAttribute)), x(d), c.src = r[d].getAttribute(l.imageUrlAttribute), w(c), c.classList.add("lite-light-fade-in"), q(), c.addEventListener("animationend", () => {
       c.classList.remove("lite-light-fade-in");
     }, { once: !0 }), o.addEventListener("touchstart", T, { passive: !0 }), o.addEventListener("touchmove", D, { passive: !0 }), o.addEventListener("touchend", I, { passive: !0 }), document.addEventListener("keydown", Y), M.addEventListener("click", X(-1)), S.addEventListener("click", X(1)), E.addEventListener("click", (i) => {
-      i.stopPropagation(), y();
-    }), o.addEventListener("click", y);
+      i.stopImmediatePropagation(), y();
+    }), o.addEventListener("click", (i) => {
+      i.stopImmediatePropagation(), y();
+    });
   });
 }
 function N(t) {

--- a/lite-light.js
+++ b/lite-light.js
@@ -346,12 +346,15 @@ export function initLiteLight(options = {}) {
     prevButton.addEventListener('click', createNavigationHandler(-1));
     nextButton.addEventListener('click', createNavigationHandler(1));
     closeButton.addEventListener('click', (e) => {
-      e.stopPropagation();
+      e.stopImmediatePropagation();
       closeLightbox();
     });
 
     // Close lightbox when clicking on background
-    lightbox.addEventListener('click', closeLightbox);
+    lightbox.addEventListener('click', (e) => {
+      e.stopImmediatePropagation();
+      closeLightbox();
+    });
   });
 }
 


### PR DESCRIPTION
Currently it happens regularly that the scroll position is reset when closing the popup.
This is because `enableBodyScroll` clears `document.body.style.top`, which is also parsed by itself to adjust `scrollY`.
As we call `stopPropagation` instead of `stopImmediatePropagation`, the function may be called multiple times for a single click.
When this happens, the first invocation restores the correct `scrollY` and following invocations reset it back to 0.

I made some small changes to avoid this annoying bug.

Best regards,
Thomas